### PR TITLE
work around the 'unused argument' warning

### DIFF
--- a/src/cn-cbor/cn-cbor.c
+++ b/src/cn-cbor/cn-cbor.c
@@ -226,6 +226,7 @@ fail:
 }
 
 static void *_cbor_calloc(size_t count, size_t size, void *context) {
+    ((void)&(context));     // use enough to clear the "unused argument" warning
     return calloc(count, size);
 }
 


### PR DESCRIPTION
This clears the 'unused argument "context"' warning (or error with -Werror)
