### PR TITLE
Arbitrary foreach method for tube_manager

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 
 Joseph D. Beshay <joseph.beshay@utdallas.edu>
 Ken Calvert <calvert@netlab.uky.edu>
+Jacob Chappell <jacob.chappell@uky.edu>
 Joe Hildebrand <jhildebr@cisco.com>
 Pål-Erik Martinsen <palmarti@cisco.com>
 Matthew A. Miller <linuxwolf@outer-planes.net>

--- a/include/tube_manager.h
+++ b/include/tube_manager.h
@@ -13,7 +13,6 @@
 #include "spud.h"
 #include "ls_error.h"
 #include "ls_event.h"
-#include "ls_htable.h"
 #include "tube.h"
 
 /**
@@ -79,6 +78,19 @@ typedef ssize_t (*tube_sendmsg_func)(int socket,
 typedef ssize_t (*tube_recvmsg_func)(int socket,
                                      struct msghdr *message,
                                      int flags);
+
+/**
+ * Type of the function called when iterating over all tubes under the manager's
+ * control.  See tube_manager_foreach.
+ *
+ * \param user_data Optional data provided
+ * \param tube_id The ID of the current tube.
+ * \param tube The current tube.
+ * \retval int Nonzero to continue iterating (continue), 0 to stop (break).
+ */
+typedef int (*tube_walker_func)(void *user_data,
+                                const struct _spud_tube_id *tube_id,
+                                struct _tube *tube);
 
 /**
  * Type of tube event data; passed to event handler.
@@ -347,10 +359,10 @@ LS_API void tube_manager_print_tubes(tube_manager *mgr);
  *
  * \invariant mgr != NULL
  * \invariant walker != NULL
- * \param[in] mgr
- * \param[in] walker
- * \param[in] data
+ * \param[in] mgr The tube manager to iterate over.
+ * \param[in] walker The walker function to be called on each iteration.
+ * \param[in] data Optional data supplied to the walker on each iteration.
  */
 LS_API void tube_manager_foreach(tube_manager *mgr,
-                                 ls_htable_walkfunc walker,
+                                 tube_walker_func walker,
                                  void *data);

--- a/include/tube_manager.h
+++ b/include/tube_manager.h
@@ -13,6 +13,7 @@
 #include "spud.h"
 #include "ls_error.h"
 #include "ls_event.h"
+#include "ls_htable.h"
 #include "tube.h"
 
 /**

--- a/include/tube_manager.h
+++ b/include/tube_manager.h
@@ -340,3 +340,16 @@ LS_API void tube_manager_set_socket_functions(tube_sendmsg_func send,
  * \param[in] mgr
  */
 LS_API void tube_manager_print_tubes(tube_manager *mgr);
+
+/**
+ * Iterate over every tube in mgr's control, performing some arbitrary action.
+ *
+ * \invariant mgr != NULL
+ * \invariant walker != NULL
+ * \param[in] mgr
+ * \param[in] walker
+ * \param[in] data
+ */
+LS_API void tube_manager_foreach(tube_manager *mgr,
+                                 ls_htable_walkfunc walker,
+                                 void *data);

--- a/src/tube_manager.c
+++ b/src/tube_manager.c
@@ -1008,3 +1008,13 @@ LS_API void tube_manager_print_tubes(tube_manager *mgr)
     assert(mgr);
     ls_htable_walk(mgr->tubes, log_walk, mgr);
 }
+
+LS_API void tube_manager_foreach(tube_manager *mgr,
+                                 ls_htable_walkfunc walker,
+                                 void *data)
+{
+    assert(mgr);
+    assert(walker);
+
+    ls_htable_walk(mgr->tubes, walker, data);
+}

--- a/src/tube_manager.c
+++ b/src/tube_manager.c
@@ -1010,11 +1010,11 @@ LS_API void tube_manager_print_tubes(tube_manager *mgr)
 }
 
 LS_API void tube_manager_foreach(tube_manager *mgr,
-                                 ls_htable_walkfunc walker,
+                                 tube_walker_func walker,
                                  void *data)
 {
     assert(mgr);
     assert(walker);
 
-    ls_htable_walk(mgr->tubes, walker, data);
+    ls_htable_walk(mgr->tubes, (ls_htable_walkfunc) walker, data);
 }

--- a/test/tube_test.c
+++ b/test/tube_test.c
@@ -8,8 +8,10 @@
 #include "tube_manager.h"
 #include "ls_sockaddr.h"
 
-// Number of tubes to create for the foreach test.
-static const int TMGR_FOREACH_NUMTUBES = 3;
+enum {
+	// Number of tubes to create for the foreach test.
+	TMGR_FOREACH_NUMTUBES = 3
+};
 
 uint8_t spud[] = { 0xd8, 0x00, 0x00, 0xd8,
                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,

--- a/test/tube_test.c
+++ b/test/tube_test.c
@@ -268,3 +268,39 @@ CTEST2(tube, print_tubes)
     ASSERT_TRUE(tube_manager_add(data->mgr, t, &data->err));
     tube_manager_print_tubes(data->mgr);
 }
+
+static int _mock_tube_walker(void *data,
+                             const spud_tube_id *tube_id,
+                             tube * t)
+{
+    UNUSED_PARAM(tube_id);
+    UNUSED_PARAM(t);
+    int *num_tubes = (int *) data;
+    (*num_tubes)++;
+    return 1;
+}
+
+CTEST2(tube, manager_foreach)
+{
+    #ifndef TMGR_FOREACH_NUMTUBES
+        #define TMGR_FOREACH_NUMTUBES 3
+    #else
+        ASSERT_FAIL();
+    #endif
+
+    tube * tubes[TMGR_FOREACH_NUMTUBES];
+    spud_tube_id ids[TMGR_FOREACH_NUMTUBES];
+
+    for (int i = 0; i < TMGR_FOREACH_NUMTUBES; ++i) {
+        ASSERT_TRUE(tube_create(&tubes[i], &data->err));
+        ASSERT_TRUE(spud_create_id(&ids[i], &data->err));
+        tube_set_info(tubes[i], -1, NULL, &ids[i]);
+        ASSERT_TRUE(tube_manager_add(data->mgr, tubes[i], &data->err));
+    }
+
+    int num_tubes = 0;
+    tube_manager_foreach(data->mgr, _mock_tube_walker, (void *) &num_tubes);
+    ASSERT_TRUE(num_tubes == TMGR_FOREACH_NUMTUBES);
+
+    #undef TMGR_FOREACH_NUMTUBES
+}

--- a/test/tube_test.c
+++ b/test/tube_test.c
@@ -271,7 +271,7 @@ CTEST2(tube, print_tubes)
 
 static int _mock_tube_walker(void *data,
                              const spud_tube_id *tube_id,
-                             tube * t)
+                             tube *t)
 {
     UNUSED_PARAM(tube_id);
     UNUSED_PARAM(t);
@@ -283,10 +283,7 @@ static int _mock_tube_walker(void *data,
 CTEST2(tube, manager_foreach)
 {
     #ifndef TMGR_FOREACH_NUMTUBES
-        #define TMGR_FOREACH_NUMTUBES 3
-    #else
-        ASSERT_FAIL();
-    #endif
+    #define TMGR_FOREACH_NUMTUBES 3
 
     tube * tubes[TMGR_FOREACH_NUMTUBES];
     spud_tube_id ids[TMGR_FOREACH_NUMTUBES];
@@ -303,4 +300,7 @@ CTEST2(tube, manager_foreach)
     ASSERT_TRUE(num_tubes == TMGR_FOREACH_NUMTUBES);
 
     #undef TMGR_FOREACH_NUMTUBES
+    #else
+    ASSERT_FAIL();
+    #endif
 }

--- a/test/tube_test.c
+++ b/test/tube_test.c
@@ -8,6 +8,9 @@
 #include "tube_manager.h"
 #include "ls_sockaddr.h"
 
+// Number of tubes to create for the foreach test.
+static const int TMGR_FOREACH_NUMTUBES = 3;
+
 uint8_t spud[] = { 0xd8, 0x00, 0x00, 0xd8,
                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                    0x00,
@@ -282,9 +285,6 @@ static int _mock_tube_walker(void *data,
 
 CTEST2(tube, manager_foreach)
 {
-    #ifndef TMGR_FOREACH_NUMTUBES
-    #define TMGR_FOREACH_NUMTUBES 3
-
     tube * tubes[TMGR_FOREACH_NUMTUBES];
     spud_tube_id ids[TMGR_FOREACH_NUMTUBES];
 
@@ -298,9 +298,4 @@ CTEST2(tube, manager_foreach)
     int num_tubes = 0;
     tube_manager_foreach(data->mgr, _mock_tube_walker, (void *) &num_tubes);
     ASSERT_TRUE(num_tubes == TMGR_FOREACH_NUMTUBES);
-
-    #undef TMGR_FOREACH_NUMTUBES
-    #else
-    ASSERT_FAIL();
-    #endif
 }


### PR DESCRIPTION
I found this necessary for an application I am writing. It is essentially a wrapper for ls_htable_walk. It is important to have this as a library routine since users cannot directly interact with the internals of the tube_manager (thus users cannot call ls_htable_walk themselves passing in mgr->tubes).
