### PR TITLE
Add tube manager reference to tube objects.

### DIFF
--- a/include/tube.h
+++ b/include/tube.h
@@ -209,6 +209,25 @@ LS_API void tube_set_state(tube *t, tube_states_t state);
 LS_API void tube_get_id(tube *t, spud_tube_id **id);
 
 /**
+ * Set the current manager of the tube.
+ *
+ * \invariant t != NULL
+ * @param[in] t     The tube to modify.
+ * @param[in] state The new tube manager.
+ */
+LS_API void tube_set_manager(tube *t, tube_manager *tmgr);
+
+/**
+ * Return the manager a tube is attached to.
+ *
+ * \invariant t != NULL
+ * \param[in] t  The tube whose manager is returned.
+ * \param[out] id  On return, contains a pointer to the tube manager. This may
+ * be NULL if the tube belongs to no manager.
+ */
+LS_API void tube_get_manager(tube *t, tube_manager **tmgr);
+
+/**
  * Set various pieces of information about the tube.
  *
  * \invariant t != NULL

--- a/src/tube.c
+++ b/src/tube.c
@@ -28,6 +28,7 @@ struct _tube
   spud_tube_id id;
   void *data;
   ls_pktinfo *pktinfo;
+  tube_manager *tmgr;
   int sock;
 };
 
@@ -42,6 +43,7 @@ LS_API bool tube_create(tube **t, ls_err *err)
         *t = NULL;
         return false;
     }
+    ret->tmgr = NULL;
     ret->sock = -1;
     ret->state = TS_UNKNOWN;
     *t = ret;
@@ -378,6 +380,18 @@ LS_API void tube_get_id(tube *t, spud_tube_id **id)
 {
     assert(t);
     *id = &t->id;
+}
+
+LS_API void tube_set_manager(tube *t, tube_manager *tmgr)
+{
+    assert(t);
+    t->tmgr = tmgr;
+}
+
+LS_API void tube_get_manager(tube *t, tube_manager **tmgr)
+{
+    assert(t);
+    *tmgr = &t->tmgr;
 }
 
 LS_API void tube_set_info(tube *t,

--- a/src/tube_manager.c
+++ b/src/tube_manager.c
@@ -430,6 +430,7 @@ LS_API bool tube_manager_add(tube_manager *mgr,
     assert(mgr);
     assert(t);
 
+    tube_set_manager(t, mgr);
     tube_get_id(t, &id);
     if (!ls_htable_put(mgr->tubes, id, t, clean_tube, err)) {
       return false;
@@ -444,6 +445,8 @@ LS_API void tube_manager_remove(tube_manager *mgr,
     spud_tube_id *id;
     assert(mgr);
     assert(t);
+
+    tube_set_manager(t, NULL);
     if (!ls_event_trigger(mgr->e_remove, t, NULL, NULL, &err)) {
         LS_LOG_ERR(err, "ls_event_trigger");
         // keep going!


### PR DESCRIPTION
I have found through writing an application that I needed to know a tube's manager. There is currently no way of doing this, except storing the manager in a static global. This patch adds a tmgr field to each tube that is automatically updated on tube_manager add/remove calls.

I will write unit tests if you all agree this is a good contribution.
